### PR TITLE
Split out SIGSYS handling and redirect accept to accept4

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -48,6 +48,7 @@ OBJECTS += \
 	tracee/mem.o		\
 	tracee/reg.o		\
 	tracee/event.o		\
+	tracee/seccomp.o        \
 	ptrace/ptrace.o		\
 	ptrace/user.o		\
 	ptrace/wait.o		\

--- a/src/tracee/seccomp.c
+++ b/src/tracee/seccomp.c
@@ -1,0 +1,59 @@
+#include <errno.h>     /* E*, */
+#include <signal.h>    /* SIGSYS, */
+
+#include "cli/note.h"
+#include "syscall/chain.h"
+#include "tracee/seccomp.h"
+
+
+int handle_seccomp_event(Tracee* tracee) {
+
+	word_t sysnum;
+	int signal;
+	word_t instr_pointer;
+
+	signal = SIGSYS;
+
+	int sigsys_fetch_status = fetch_regs(tracee);
+	if (sigsys_fetch_status != 0) {
+		VERBOSE(tracee, 1, "Couldn't fetch regs on seccomp SIGSYS");
+		return signal;
+	}
+	print_current_regs(tracee, 3, "seccomp SIGSYS");
+	tracee->restore_original_regs = false;
+
+	sysnum = get_sysnum(tracee, CURRENT);
+
+	switch (sysnum) {
+	case PR_accept:
+		set_sysnum(tracee, PR_accept4);
+		poke_reg(tracee, SYSARG_4, 0);
+
+		/* Move the instruction pointer back to the original trap */
+		instr_pointer = peek_reg(tracee, CURRENT, INSTR_POINTER);
+		poke_reg(tracee, INSTR_POINTER, instr_pointer - SYSTRAP_SIZE);
+		/* Break as usual on entry to syscall */
+		tracee->restart_how = PTRACE_SYSCALL;
+		push_specific_regs(tracee, true);
+
+		/* Swallow signal */
+		signal = 0;
+		break;
+
+	case PR_set_robust_list:
+	default:
+		/* Set errno to -ENOSYS */
+		poke_reg(tracee, SYSARG_RESULT, -ENOSYS);
+		push_specific_regs(tracee, false);
+
+		/* Swallow signal */
+		signal = 0;
+		break;
+	}
+
+	/* Reset status so next SIGTRAP | 0x80 is
+	 * recognized as syscall entry */
+	tracee->status = 0;
+
+	return signal;
+}

--- a/src/tracee/seccomp.h
+++ b/src/tracee/seccomp.h
@@ -1,0 +1,3 @@
+#include "tracee/tracee.h"
+
+int handle_seccomp_event(Tracee* tracee);


### PR DESCRIPTION
This fixes SIGSYS on Oreo for processes that call `accept`. I can't see a recent change to bionic, but accept4 definitely seems to be the [supported call](https://android.googlesource.com/platform/bionic/+/903b788).

I'm not massively familiar with this codebase, and I've basically pulled out the code from 454b0b1 and chain.c. It took a while to work out something that does the right thing, so it's likely I've misunderstood how it should work or overlooked a corner case.

Tested on aarch64, Android 8.0.0, kernel 3.18.66-perf targetting `nc -l -p 8080` and `chromium-browser --headless` on Ubuntu.