### PR TITLE
fake_id0: set rgid and sgid if and only if euid is 0

### DIFF
--- a/src/extension/fake_id0/fake_id0.c
+++ b/src/extension/fake_id0/fake_id0.c
@@ -339,7 +339,7 @@ static int handle_sysenter_end(Tracee *tracee, const Config *config)
 									\
 	/* "If the effective UID of the caller is root, the real UID	\
 	 * and saved set-user-ID are also set." -- man setuid */	\
-	if (config->e ## id == 0) {					\
+	if (config->euid == 0) {					\
 		config->r ## id = id;					\
 		config->s ## id = id;					\
 	}								\


### PR DESCRIPTION
Since we consider whether the process is privileged based on
whether its euid == 0 but not egid.