### PR TITLE
--input and --output -> --input-target and --output-target

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -133,8 +133,8 @@ LINK    = $($(quiet)LD) -o $@ $^ $(LDFLAGS)
 
 OBJIFY = $($(quiet)GEN)									\
 	$(OBJCOPY)									\
-		--input binary								\
-		--output `env LANG=C $(OBJDUMP) -f cli/cli.o |				\
+		--input-target=binary								\
+		--output-target=`env LANG=C $(OBJDUMP) -f cli/cli.o |				\
 			grep 'file format' | awk '{print $$4}'`				\
 		--binary-architecture `env LANG=C $(OBJDUMP) -f cli/cli.o |		\
 				grep architecture | cut -f 1 -d , | awk '{print $$2}'`	\


### PR DESCRIPTION
When I was trying to compile in I don't remember which Termux or Arch Linux in Termux. I was getting error of --input and --output option doesn't exist. In the manpage and google suggest --input-target and --output-target.

http://man7.org/linux/man-pages/man1/objcopy.1.html

Although it doesn't have any issue in Debian but I think we should follow what it's in the manpage.