### PR TITLE
fake_id0: do not re-translate the chroot path

### DIFF
--- a/src/extension/fake_id0/chroot.c
+++ b/src/extension/fake_id0/chroot.c
@@ -8,10 +8,6 @@
 
 int handle_chroot_exit_end(Tracee *tracee, Config *config) {
 	char path[PATH_MAX];
-	char path_translated[PATH_MAX];
-	char path_translated_absolute[PATH_MAX];
-	char root_translated[PATH_MAX];
-	char root_translated_absolute[PATH_MAX];
 	word_t input;
 	int status;
 	word_t result;
@@ -29,18 +25,9 @@ int handle_chroot_exit_end(Tracee *tracee, Config *config) {
 	status = read_path(tracee, path, input);
 	if (status < 0)
 		return status;
-	status = translate_path(tracee, path_translated, AT_FDCWD, path, false);
-	if (status < 0)
-		return status;
-	realpath(path_translated, path_translated_absolute);
-
-	status = translate_path(tracee, root_translated, AT_FDCWD, get_root(tracee), false);
-	if (status < 0)
-		return status;
-	realpath(root_translated, root_translated_absolute);
 
 	/* Only "new rootfs == current rootfs" is supported yet.  */
-	status = compare_paths(root_translated_absolute, path_translated_absolute);
+	status = compare_paths(get_root(tracee), path);
 	if (status != PATHS_ARE_EQUAL)
 		return 0;
 

--- a/src/extension/fake_id0/chroot.c
+++ b/src/extension/fake_id0/chroot.c
@@ -8,6 +8,7 @@
 
 int handle_chroot_exit_end(Tracee *tracee, Config *config) {
 	char path[PATH_MAX];
+	char path_absolute[PATH_MAX];
 	word_t input;
 	int status;
 	word_t result;
@@ -26,8 +27,10 @@ int handle_chroot_exit_end(Tracee *tracee, Config *config) {
 	if (status < 0)
 		return status;
 
+	realpath(path, path_absolute);
+
 	/* Only "new rootfs == current rootfs" is supported yet.  */
-	status = compare_paths(get_root(tracee), path);
+	status = compare_paths(get_root(tracee), path_absolute);
 	if (status != PATHS_ARE_EQUAL)
 		return 0;
 


### PR DESCRIPTION
The call to chroot "/" from UID 0 may fail with "No such file or directory". This call is invoked e.g. by pacman during the post-install.

The culprit is [this commit](https://github.com/termux/proot/commit/ef291206e16231ba698989d59a4324a3f8508fe7), which added extra calls to translate_path and realpath. These are unnecessary because the function handling chroot, which is invoked from SYSCALL_EXIT_END, already receives the path translated (during the enter syscall, translate_sysarg() ultimately invokes translate_path() and stores it via set_sysarg_path()). The mentioned commit even tries to translate the path returned by get_root(tracee). It was trying to solve [some issue](https://github.com/Hax4us/TermuxAlpine/issues/1) which in the end was not solved, as the latest posts in that thread acknowledge.

The duplicated translation try may accidentally be harmless but may cause errors depending on the bindings configuration. I think that this may have not been reported until now because many distros choose to bind paths in /data, usually within the guest root filesystem. When that is not the case (e.g. a "pure" Linux root directory emulation) the substitute_binding() step during the translation fails and ruins the chroot.

I revert here to the original implementation (which of course already supported relative paths). 