### PR TITLE
Add seccomp workarounds for setresuid/setresgid

### DIFF
--- a/src/tracee/seccomp.c
+++ b/src/tracee/seccomp.c
@@ -522,6 +522,32 @@ static int handle_seccomp_event_common(Tracee *tracee)
 		break;
 	}
 
+	case PR_setresuid:
+	case PR_setresgid:
+	{
+		gid_t rxid, exid, sxid, rxid_, exid_, sxid_;
+		rxid = peek_reg(tracee, CURRENT, SYSARG_1);
+		exid = peek_reg(tracee, CURRENT, SYSARG_2);
+		sxid = peek_reg(tracee, CURRENT, SYSARG_3);
+		if (sysnum == PR_setresuid)
+			ret = getresuid(&rxid_, &exid_, &sxid_);
+		else if (sysnum == PR_setresgid)
+			ret = getresgid(&rxid_, &exid_, &sxid_);
+		if (ret) {  // EFAULT = address outside address space
+			set_result_after_seccomp(tracee, -EPERM);
+			break;
+		}
+		ret = 0;
+		if (rxid != rxid_ && rxid != -1)
+			ret = -EPERM;
+		if (exid != exid_ && exid != -1)
+			ret = -EPERM;
+		if (sxid != sxid_ && sxid != -1)
+			ret = -EPERM;
+		set_result_after_seccomp(tracee, ret);
+		break;
+	}
+
 	case PR_set_robust_list:
 	default:
 		/* Set errno to -ENOSYS */


### PR DESCRIPTION
When seccomp denies `setresuid`/`setresgid`, assume there's nothing we can do but translate them to either a 0 on a no-op or a -EPERM on an actual attempt at changing something.

Disclaimer: [I can't honestly say I have a firm grasp of the all, or, rather, any of the intricacies involved](https://knowyourmeme.com/photos/234767-i-have-no-idea-what-im-doing), but it seems to fix [a bug that irked me for quite a while](https://github.com/t184256/nix-on-droid/issues/91) and I don't see anything obviously wrong with it.