### PR TITLE
Hijack AT_EXECFN value with actual executable name

### DIFF
--- a/src/execve/exit.c
+++ b/src/execve/exit.c
@@ -205,6 +205,14 @@ static int transfer_load_script(Tracee *tracee)
 		page_mask = ~(page_size - 1);
 	}
 
+	/* Capture argv[0]'s address from the initial stack as the correct
+	 * AT_EXECFN value. The kernel sets AT_EXECFN to the loader temp file
+	 * path; argv[0] holds the actual program name. This is stored so that
+	 * prctl(PR_GET_AUXV) can be fixed up later in the syscall exit handler,
+	 * since PR_GET_AUXV reads from kernel memory and bypasses the loader's
+	 * in-memory auxv patch. */
+	tracee->execfn_addr = peek_word(tracee, stack_pointer + sizeof_word(tracee));
+
 	needs_executable_stack = (tracee->load_info->needs_executable_stack
 				|| (   tracee->load_info->interp != NULL
 				    && tracee->load_info->interp->needs_executable_stack));

--- a/src/syscall/exit.c
+++ b/src/syscall/exit.c
@@ -24,6 +24,7 @@
 #include <sys/utsname.h> /* struct utsname, */
 #include <linux/net.h>   /* SYS_*, */
 #include <linux/ioctl.h> /* _IOW, */
+#include <linux/prctl.h> /* PR_GET_AUXV, */
 #include <string.h>      /* strlen(3), */
 
 #include "cli/note.h"
@@ -460,6 +461,52 @@ void translate_syscall_exit(Tracee *tracee)
 	case PR_execveat:
 		translate_execve_exit(tracee);
 		goto end;
+
+	case PR_prctl: {
+		word_t option;
+		word_t buf_addr;
+		word_t buf_max;
+		word_t offset;
+		word_t entry_size;
+		word_t type;
+
+		/* Only intercept PR_GET_AUXV. */
+		option = peek_reg(tracee, ORIGINAL, SYSARG_1);
+		if (option != PR_GET_AUXV)
+			goto end;
+
+		/* Error or no execfn to fix: nothing to do. */
+		if ((int) syscall_result < 0)
+			goto end;
+		if (tracee->execfn_addr == 0)
+			goto end;
+
+		/* PR_GET_AUXV returns the auxv size; if it exceeds the buffer
+		 * arg, the kernel did not write anything (buffer too small). */
+		buf_max = peek_reg(tracee, ORIGINAL, SYSARG_3);
+		if (syscall_result > buf_max)
+			goto end;
+
+		/* Scan the returned auxv buffer for AT_EXECFN and patch its
+		 * value to point to argv[0] instead of the loader temp file. */
+		buf_addr   = peek_reg(tracee, ORIGINAL, SYSARG_2);
+		entry_size = 2 * sizeof_word(tracee);
+
+		for (offset = 0; offset + entry_size <= syscall_result; offset += entry_size) {
+			errno = 0;
+			type = peek_word(tracee, buf_addr + offset);
+			if (errno != 0)
+				break;
+			if (type == AT_NULL)
+				break;
+			if (type == AT_EXECFN) {
+				poke_word(tracee, buf_addr + offset + sizeof_word(tracee),
+					  tracee->execfn_addr);
+				break;
+			}
+		}
+		goto end;
+	}
 
 	case PR_ptrace:
 		status = translate_ptrace_exit(tracee);

--- a/src/syscall/seccomp.c
+++ b/src/syscall/seccomp.c
@@ -385,7 +385,7 @@ static FilteredSysnum proot_sysnums[] = {
 	{ PR_open,		0 },
 	{ PR_openat,		0 },
 	{ PR_pivot_root,	0 },
-	{ PR_prctl, 		0 },
+	{ PR_prctl, 		FILTER_SYSEXIT },
 	{ PR_prlimit64,		FILTER_SYSEXIT },
 	{ PR_ptrace,		FILTER_SYSEXIT },
 	{ PR_readlink,		FILTER_SYSEXIT },

--- a/src/tracee/tracee.h
+++ b/src/tracee/tracee.h
@@ -215,6 +215,12 @@ typedef struct tracee {
 	 * execve sysexit.  */
 	struct load_info *load_info;
 
+	/* Address of argv[0] string in the tracee's initial stack, captured
+	 * at execve sysexit. Used to fix AT_EXECFN in prctl(PR_GET_AUXV)
+	 * responses: the kernel's saved auxv has AT_EXECFN pointing to the
+	 * loader temp file, but we want it to point to the actual program name. */
+	word_t execfn_addr;
+
 #ifdef HAS_POKEDATA_WORKAROUND
 	word_t pokedata_workaround_stub_addr;
 	bool pokedata_workaround_cancelled_syscall;


### PR DESCRIPTION
Mainly for fixing rust coreutils (uutils) in ubuntu proot, but should work for any other program using AT_EXECFN for retrieving executable path.