### PR TITLE
Fix executable path exposed by aux vector (AT_EXECFN)

### DIFF
--- a/src/execve/exit.c
+++ b/src/execve/exit.c
@@ -205,6 +205,14 @@ static int transfer_load_script(Tracee *tracee)
 		page_mask = ~(page_size - 1);
 	}
 
+	/* Capture argv[0]'s address from the initial stack as the correct
+	 * AT_EXECFN value. The kernel sets AT_EXECFN to the loader temp file
+	 * path; argv[0] holds the actual program name. This is stored so that
+	 * prctl(PR_GET_AUXV) can be fixed up later in the syscall exit handler,
+	 * since PR_GET_AUXV reads from kernel memory and bypasses the loader's
+	 * in-memory auxv patch. */
+	tracee->execfn_addr = peek_word(tracee, stack_pointer + sizeof_word(tracee));
+
 	needs_executable_stack = (tracee->load_info->needs_executable_stack
 				|| (   tracee->load_info->interp != NULL
 				    && tracee->load_info->interp->needs_executable_stack));
@@ -404,6 +412,8 @@ void translate_execve_exit(Tracee *tracee)
 {
 	word_t syscall_result;
 	int status;
+
+	tracee->auxv_fd = -1;
 
 	if (tracee->skip_proot_loader) {
 		tracee->restore_original_regs = false;

--- a/src/syscall/enter.c
+++ b/src/syscall/enter.c
@@ -401,6 +401,14 @@ int translate_syscall_enter(Tracee *tracee)
 	case PR_open:
 		flags = peek_reg(tracee, CURRENT, SYSARG_2);
 
+		if (tracee->execfn_addr != 0) {
+			(void) read_string(tracee, path, peek_reg(tracee, CURRENT, SYSARG_1), PATH_MAX);
+			if (strcmp(path, "/proc/self/auxv") == 0) {
+				tracee->sysexit_pending = true;
+				tracee->restart_how = PTRACE_SYSCALL;
+			}
+		}
+
 		if (   ((flags & O_NOFOLLOW) != 0)
 		    || ((flags & O_EXCL) != 0 && (flags & O_CREAT) != 0))
 			status = translate_sysarg(tracee, SYSARG_1, SYMLINK);
@@ -523,6 +531,11 @@ int translate_syscall_enter(Tracee *tracee)
 		if (status < 0)
 			break;
 
+		if (tracee->execfn_addr != 0 && strcmp(path, "/proc/self/auxv") == 0) {
+			tracee->sysexit_pending = true;
+			tracee->restart_how = PTRACE_SYSCALL;
+		}
+
 		if (   ((flags & O_NOFOLLOW) != 0)
 			|| ((flags & O_EXCL) != 0 && (flags & O_CREAT) != 0))
 			status = translate_path2(tracee, dirfd, path, SYSARG_2, SYMLINK);
@@ -608,6 +621,11 @@ int translate_syscall_enter(Tracee *tracee)
 			set_sysnum(tracee, PR_void);
 			status = 0;
 		}
+		/* Need sysexit to patch AT_EXECFN in the returned buffer. */
+		if (peek_reg(tracee, CURRENT, SYSARG_1) == PR_GET_AUXV) {
+			tracee->sysexit_pending = true;
+			tracee->restart_how = PTRACE_SYSCALL;
+		}
 		break;
 
 #ifdef __ANDROID__
@@ -665,6 +683,13 @@ int translate_syscall_enter(Tracee *tracee)
 			}
 			break;
 		}
+	case PR_close:
+		/* Stop tracking auxv_fd once the tracee closes it. */
+		if (tracee->auxv_fd >= 0
+		    && (int) peek_reg(tracee, CURRENT, SYSARG_1) == tracee->auxv_fd)
+			tracee->auxv_fd = -1;
+		break;
+
 	}
 
 

--- a/src/syscall/enter.c
+++ b/src/syscall/enter.c
@@ -401,12 +401,11 @@ int translate_syscall_enter(Tracee *tracee)
 	case PR_open:
 		flags = peek_reg(tracee, CURRENT, SYSARG_2);
 
-		if (tracee->execfn_addr != 0) {
-			(void) read_string(tracee, path, peek_reg(tracee, CURRENT, SYSARG_1), PATH_MAX);
-			if (strcmp(path, "/proc/self/auxv") == 0) {
-				tracee->sysexit_pending = true;
-				tracee->restart_how = PTRACE_SYSCALL;
-			}
+		if (tracee->execfn_addr != 0
+		    && read_string(tracee, path, peek_reg(tracee, CURRENT, SYSARG_1), PATH_MAX) > 0
+		    && strcmp(path, "/proc/self/auxv") == 0) {
+			tracee->sysexit_pending = true;
+			tracee->restart_how = PTRACE_SYSCALL;
 		}
 
 		if (   ((flags & O_NOFOLLOW) != 0)

--- a/src/syscall/enter.c
+++ b/src/syscall/enter.c
@@ -622,6 +622,9 @@ int translate_syscall_enter(Tracee *tracee)
 			status = 0;
 		}
 		/* Need sysexit to patch AT_EXECFN in the returned buffer. */
+#ifndef PR_GET_AUXV
+#define PR_GET_AUXV 0x41555856
+#endif
 		if (peek_reg(tracee, CURRENT, SYSARG_1) == PR_GET_AUXV) {
 			tracee->sysexit_pending = true;
 			tracee->restart_how = PTRACE_SYSCALL;

--- a/src/syscall/exit.c
+++ b/src/syscall/exit.c
@@ -24,6 +24,7 @@
 #include <sys/utsname.h> /* struct utsname, */
 #include <linux/net.h>   /* SYS_*, */
 #include <linux/ioctl.h> /* _IOW, */
+#include <linux/prctl.h> /* PR_GET_AUXV, */
 #include <string.h>      /* strlen(3), */
 
 #include "cli/note.h"
@@ -460,6 +461,118 @@ void translate_syscall_exit(Tracee *tracee)
 	case PR_execveat:
 		translate_execve_exit(tracee);
 		goto end;
+
+	case PR_openat:
+	case PR_open: {
+		/* Track /proc/self/auxv opens so read() results can be patched.
+		 * Needed on kernels < 6.4 where prctl(PR_GET_AUXV) is absent and
+		 * rustix falls back to reading /proc/self/auxv directly. */
+		char path_buf[sizeof("/proc/self/auxv")];
+		Reg path_reg = (get_sysnum(tracee, ORIGINAL) == PR_openat) ? SYSARG_2 : SYSARG_1;
+
+		if ((int) syscall_result < 0)
+			goto end;
+		if (tracee->execfn_addr == 0)
+			goto end;
+		if (read_string(tracee, path_buf,
+		                peek_reg(tracee, ORIGINAL, path_reg),
+		                sizeof(path_buf)) <= 0)
+			goto end;
+		if (strcmp(path_buf, "/proc/self/auxv") != 0)
+			goto end;
+
+		tracee->auxv_fd = (int) syscall_result;
+		tracee->sysexit_pending = true;
+		tracee->restart_how = PTRACE_SYSCALL;
+		goto end;
+	}
+
+	case PR_read: {
+		/* Patch AT_EXECFN in data read from /proc/self/auxv. */
+		word_t fd, buf_addr, result, offset, entry_size, type;
+
+		if (tracee->auxv_fd < 0 || tracee->execfn_addr == 0)
+			goto end;
+
+		result = syscall_result;
+		if ((word_t) result == 0 || (ssize_t) result < 0)
+			goto end;
+
+		fd = peek_reg(tracee, ORIGINAL, SYSARG_1);
+		if ((int) fd != tracee->auxv_fd)
+			goto end;
+
+		buf_addr   = peek_reg(tracee, ORIGINAL, SYSARG_2);
+		entry_size = 2 * sizeof_word(tracee);
+
+		for (offset = 0; offset + entry_size <= result; offset += entry_size) {
+			errno = 0;
+			type = peek_word(tracee, buf_addr + offset);
+			if (errno != 0)
+				break;
+			if (type == AT_NULL)
+				break;
+			if (type == AT_EXECFN) {
+				poke_word(tracee, buf_addr + offset + sizeof_word(tracee),
+				          tracee->execfn_addr);
+				break;
+			}
+		}
+
+		/* Stay in PTRACE_SYSCALL mode to intercept close(auxv_fd). */
+		tracee->sysexit_pending = true;
+		tracee->restart_how = PTRACE_SYSCALL;
+		goto end;
+	}
+
+	case PR_prctl: {
+#ifndef PR_GET_AUXV
+#define PR_GET_AUXV 0x41555856
+#endif
+		word_t option;
+		word_t buf_addr;
+		word_t buf_max;
+		word_t offset;
+		word_t entry_size;
+		word_t type;
+
+		/* Only intercept PR_GET_AUXV. */
+		option = peek_reg(tracee, ORIGINAL, SYSARG_1);
+		if (option != PR_GET_AUXV)
+			goto end;
+
+		/* Error or no execfn to fix: nothing to do. */
+		if ((int) syscall_result < 0)
+			goto end;
+		if (tracee->execfn_addr == 0)
+			goto end;
+
+		/* PR_GET_AUXV returns the auxv size; if it exceeds the buffer
+		 * arg, the kernel did not write anything (buffer too small). */
+		buf_max = peek_reg(tracee, ORIGINAL, SYSARG_3);
+		if (syscall_result > buf_max)
+			goto end;
+
+		/* Scan the returned auxv buffer for AT_EXECFN and patch its
+		 * value to point to argv[0] instead of the loader temp file. */
+		buf_addr   = peek_reg(tracee, ORIGINAL, SYSARG_2);
+		entry_size = 2 * sizeof_word(tracee);
+
+		for (offset = 0; offset + entry_size <= syscall_result; offset += entry_size) {
+			errno = 0;
+			type = peek_word(tracee, buf_addr + offset);
+			if (errno != 0)
+				break;
+			if (type == AT_NULL)
+				break;
+			if (type == AT_EXECFN) {
+				poke_word(tracee, buf_addr + offset + sizeof_word(tracee),
+					  tracee->execfn_addr);
+				break;
+			}
+		}
+		goto end;
+	}
 
 	case PR_ptrace:
 		status = translate_ptrace_exit(tracee);

--- a/src/syscall/seccomp.c
+++ b/src/syscall/seccomp.c
@@ -340,6 +340,7 @@ static FilteredSysnum proot_sysnums[] = {
 	{ PR_chown,		0 },
 	{ PR_chown32,		0 },
 	{ PR_chroot,		0 },
+	{ PR_close,		0 },
 	{ PR_connect,		0 },
 	{ PR_creat,		0 },
 	{ PR_execve,		FILTER_SYSEXIT },

--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -596,6 +596,11 @@ int handle_tracee_event(Tracee *tracee, int tracee_status)
 			tracee->restart_how = PTRACE_CONT;
 			translate_syscall(tracee);
 
+			/* Sysenter handler may have requested sysexit
+			 * interception by setting sysexit_pending.  */
+			if (tracee->sysexit_pending)
+				tracee->restart_how = PTRACE_SYSCALL;
+
 			/* This syscall has disabled seccomp, so move
 			 * the ptrace flow back to the common path to
 			 * ensure its sysexit will be handled.  */

--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -433,6 +433,8 @@ int new_child(Tracee *parent, word_t clone_flags)
 	child->verbose = parent->verbose;
 	child->seccomp = parent->seccomp;
 	child->sysexit_pending = parent->sysexit_pending;
+	child->execfn_addr = parent->execfn_addr;
+	child->auxv_fd = parent->auxv_fd;
 #ifdef HAS_POKEDATA_WORKAROUND
 	child->pokedata_workaround_stub_addr = parent->pokedata_workaround_stub_addr;
 #endif

--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -194,6 +194,7 @@ Tracee *new_dummy_tracee(TALLOC_CTX *context)
 	 * name-space and heap.  */
 	tracee->fs = talloc_zero(tracee, FileSystemNameSpace);
 	tracee->heap = talloc_zero(tracee, Heap);
+	tracee->auxv_fd = -1;
 	if (tracee->fs == NULL || tracee->heap == NULL)
 		goto no_mem;
 

--- a/src/tracee/tracee.h
+++ b/src/tracee/tracee.h
@@ -215,6 +215,17 @@ typedef struct tracee {
 	 * execve sysexit.  */
 	struct load_info *load_info;
 
+	/* Address of argv[0] string in the tracee's initial stack, captured
+	 * at execve sysexit. Used to fix AT_EXECFN in prctl(PR_GET_AUXV)
+	 * responses: the kernel's saved auxv has AT_EXECFN pointing to the
+	 * loader temp file, but we want it to point to the actual program name. */
+	word_t execfn_addr;
+
+	/* fd the tracee used to open /proc/self/auxv, tracked so that read()
+	 * calls on it can have AT_EXECFN patched (fallback for kernels < 6.4
+	 * that don't support prctl(PR_GET_AUXV)). -1 when not active. */
+	int auxv_fd;
+
 #ifdef HAS_POKEDATA_WORKAROUND
 	word_t pokedata_workaround_stub_addr;
 	bool pokedata_workaround_cancelled_syscall;


### PR DESCRIPTION
Mainly for fixing rust coreutils (uutils) in ubuntu proot, but should work for any other program using AT_EXECFN for retrieving executable path.

2 methods: prctl (appears to be not working on some devices) and /proc/self/auxv as fallback.