### PR TITLE
Prevent crash on devices with very old kernels

### DIFF
--- a/src/syscall/enter.c
+++ b/src/syscall/enter.c
@@ -43,6 +43,7 @@
 #include "tracee/reg.h"
 #include "tracee/mem.h"
 #include "tracee/abi.h"
+#include "tracee/event.h"
 #include "path/path.h"
 #include "path/canon.h"
 #include "arch.h"
@@ -640,6 +641,28 @@ int translate_syscall_enter(Tracee *tracee)
 		/* Prevent tracees from setting dumpable flag.
 		 * (Otherwise it could break tracee memory access)  */
 		if (peek_reg(tracee, CURRENT, SYSARG_1) == PR_SET_DUMPABLE) {
+			set_sysnum(tracee, PR_void);
+			status = 0;
+		}
+		/* On kernels that don't support PTRACE_O_TRACESECCOMP,
+		 * SECCOMP_RET_TRACE causes filtered syscalls to return
+		 * -ENOSYS to the tracee without generating a ptrace event.
+		 * If a tracee installs its own SECCOMP_MODE_FILTER, the
+		 * syscalls proot must intercept (open, execve, ...) would
+		 * silently fail from proot's perspective.  Block the filter
+		 * installation so proot's PTRACE_SYSCALL path keeps working.
+		 * This situation is typical on old ARM 32-bit Android kernels
+		 * that backported seccomp but not PTRACE_O_TRACESECCOMP.  */
+#ifndef SECCOMP_MODE_FILTER
+#define SECCOMP_MODE_FILTER 2
+#endif
+		if (peek_reg(tracee, CURRENT, SYSARG_1) == PR_SET_SECCOMP
+		    && peek_reg(tracee, CURRENT, SYSARG_2) == SECCOMP_MODE_FILTER
+		    && !seccomp_ptrace_event_is_supported()) {
+			VERBOSE(tracee, 1, "blocking tracee prctl(PR_SET_SECCOMP, "
+				"SECCOMP_MODE_FILTER): kernel lacks "
+				"PTRACE_EVENT_SECCOMP support");
+			poke_reg(tracee, SYSARG_RESULT, (word_t) -EPERM);
 			set_sysnum(tracee, PR_void);
 			status = 0;
 		}

--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -51,6 +51,7 @@
 #include "compat.h"
 
 static bool seccomp_after_ptrace_enter = false;
+static bool seccomp_ptrace_event_supported = false;
 
 /**
  * Start @tracee->exe with the given @argv[].  This function
@@ -459,6 +460,17 @@ int handle_tracee_event(Tracee *tracee, int tracee_status)
 					note(tracee, ERROR, SYSTEM, "ptrace(PTRACE_SETOPTIONS)");
 					exit(EXIT_FAILURE);
 				}
+				/* Without PTRACE_O_TRACESECCOMP, a seccomp filter
+				 * installed by the tracee that returns
+				 * SECCOMP_RET_TRACE would silently return -ENOSYS
+				 * for filtered syscalls instead of generating a
+				 * ptrace event.  Record this so the prctl handler
+				 * can refuse PR_SET_SECCOMP, SECCOMP_MODE_FILTER
+				 * from the tracee to keep proot's syscall
+				 * interception working.  */
+				seccomp_ptrace_event_supported = false;
+			} else {
+				seccomp_ptrace_event_supported = true;
 			}
 		}
 			/* Fall through. */
@@ -701,6 +713,19 @@ int handle_tracee_event(Tracee *tracee, int tracee_status)
 bool seccomp_event_happens_after_enter_sigtrap()
 {
 	return !seccomp_after_ptrace_enter;
+}
+
+/**
+ * Return true if PTRACE_O_TRACESECCOMP is supported by the kernel,
+ * i.e. the kernel will generate PTRACE_EVENT_SECCOMP stops instead of
+ * silently returning -ENOSYS when a seccomp filter returns
+ * SECCOMP_RET_TRACE.  When this returns false, the prctl handler
+ * blocks tracee attempts to install SECCOMP_MODE_FILTER so that
+ * proot's PTRACE_SYSCALL interception path remains functional.
+ */
+bool seccomp_ptrace_event_is_supported()
+{
+	return seccomp_ptrace_event_supported;
 }
 
 /**

--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -54,6 +54,24 @@ static bool seccomp_after_ptrace_enter = false;
 static bool seccomp_ptrace_event_supported = false;
 
 /**
+ * Return true if the running kernel is new enough to generate
+ * PTRACE_EVENT_SECCOMP stops (requires Linux >= 3.5).  Old Android
+ * kernels (e.g. 3.1.x nougat) backport SECCOMP_MODE_FILTER but
+ * silently accept PTRACE_O_TRACESECCOMP option bits without actually
+ * implementing the event, so we can't rely on PTRACE_SETOPTIONS alone.
+ */
+static bool kernel_supports_ptrace_event_seccomp(void)
+{
+	struct utsname uts;
+	int major = 0, minor = 0;
+
+	if (uname(&uts) < 0)
+		return true; /* assume supported if uname fails */
+	sscanf(uts.release, "%d.%d", &major, &minor);
+	return (major > 3) || (major == 3 && minor >= 5);
+}
+
+/**
  * Start @tracee->exe with the given @argv[].  This function
  * returns -errno if an error occurred, otherwise 0.
  */
@@ -470,7 +488,13 @@ int handle_tracee_event(Tracee *tracee, int tracee_status)
 				 * interception working.  */
 				seccomp_ptrace_event_supported = false;
 			} else {
-				seccomp_ptrace_event_supported = true;
+				/* PTRACE_SETOPTIONS succeeded, but some old
+				 * Android kernels (e.g. 3.1.x nougat) silently
+				 * accept unknown option bits without implementing
+				 * them.  Cross-check with the kernel version:
+				 * PTRACE_EVENT_SECCOMP requires Linux >= 3.5.  */
+				seccomp_ptrace_event_supported =
+					kernel_supports_ptrace_event_seccomp();
 			}
 		}
 			/* Fall through. */

--- a/src/tracee/event.h
+++ b/src/tracee/event.h
@@ -32,5 +32,6 @@ extern int event_loop();
 extern int handle_tracee_event(Tracee *tracee, int tracee_status);
 extern bool restart_tracee(Tracee *tracee, int signal);
 extern bool seccomp_event_happens_after_enter_sigtrap();
+extern bool seccomp_ptrace_event_is_supported();
 
 #endif /* TRACEE_EVENT_H */


### PR DESCRIPTION
PRoot can be non-functional on devices with extremely old kernel versions, discovered this while testing proot-distro on a very old Android tablet with custom Android 7.

```
~ $ uname -a
Linux localhost 3.1.10-nougat-gd41f42062c6 #1 SMP PREEMPT Sat Mar 13 20:15:57 UTC 2021 armv7l Android
```

```
~ $ proot bash
proot info: vpid 1: terminated with signal 7
~ $ proot-distro login debian-sid
stack corruption detected
proot info: vpid 1: terminated with signal 7
```

Technically `PROOT_NO_SECCOMP=1` can be used as workaround, but this fix should be better.