### PR TITLE
syscall: hide PRoot's internal no_new_privs flag from the guest

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -210,6 +210,9 @@
 #    ifndef PR_SET_NO_NEW_PRIVS
 #        define PR_SET_NO_NEW_PRIVS	38
 #    endif
+#    ifndef PR_GET_NO_NEW_PRIVS
+#        define PR_GET_NO_NEW_PRIVS	39
+#    endif
 #    ifndef PR_SET_SECCOMP
 #        define PR_SET_SECCOMP		22
 #    endif

--- a/src/execve/exit.c
+++ b/src/execve/exit.c
@@ -417,6 +417,7 @@ void translate_execve_exit(Tracee *tracee)
 
 	if (tracee->skip_proot_loader) {
 		tracee->restore_original_regs = false;
+		tracee->seen_execve = true;
 		return;
 	}
 
@@ -480,6 +481,10 @@ void translate_execve_exit(Tracee *tracee)
 	syscall_result = peek_reg(tracee, CURRENT, SYSARG_RESULT);
 	if ((int) syscall_result < 0)
 		return;
+
+	/* The guest program is now running; PR_SET_NO_NEW_PRIVS calls from
+	 * here on belong to the guest, not to PRoot's own pre-execve setup. */
+	tracee->seen_execve = true;
 
 	/* Execve happened; commit the new "/proc/self/exe".  */
 	if (tracee->new_exe != NULL) {

--- a/src/syscall/enter.c
+++ b/src/syscall/enter.c
@@ -2267,6 +2267,22 @@ int translate_syscall_enter(Tracee *tracee)
 			tracee->sysexit_pending = true;
 			tracee->restart_how = PTRACE_SYSCALL;
 		}
+		/* PRoot always sets PR_SET_NO_NEW_PRIVS in the child before
+		 * execve (a precondition for its seccomp filter), so the real
+		 * flag is on even though the guest never asked for it.  Report
+		 * the guest's own intent instead: answer PR_GET_NO_NEW_PRIVS
+		 * from tracee->no_new_privs without running the real syscall,
+		 * and observe the tracee's own PR_SET_NO_NEW_PRIVS at sysexit.
+		 * Tools like sudo-rs refuse to run when the flag appears set. */
+		if (peek_reg(tracee, CURRENT, SYSARG_1) == PR_GET_NO_NEW_PRIVS) {
+			poke_reg(tracee, SYSARG_RESULT, tracee->no_new_privs ? 1 : 0);
+			set_sysnum(tracee, PR_void);
+			status = 0;
+		}
+		if (peek_reg(tracee, CURRENT, SYSARG_1) == PR_SET_NO_NEW_PRIVS) {
+			tracee->sysexit_pending = true;
+			tracee->restart_how = PTRACE_SYSCALL;
+		}
 		break;
 
 	case PR_ioctl: {

--- a/src/syscall/exit.c
+++ b/src/syscall/exit.c
@@ -568,8 +568,24 @@ void translate_syscall_exit(Tracee *tracee)
 		word_t entry_size;
 		word_t type;
 
-		/* Only intercept PR_GET_AUXV. */
 		option = peek_reg(tracee, ORIGINAL, SYSARG_1);
+
+		/* Record the tracee's own request for the "no new privileges"
+		 * flag so a later PR_GET_NO_NEW_PRIVS (answered at sysenter)
+		 * reports the guest's intent rather than the flag PRoot set
+		 * itself.  A successful call implies arg2 == 1, the only value
+		 * the kernel accepts.  PRoot sets the real flag in the launch
+		 * child before the initial execve (see enable_syscall_filtering),
+		 * so only count calls made once the guest program is running
+		 * (tracee->seen_execve); the flag is a one-way latch and is
+		 * never cleared, matching the kernel's fork/execve semantics. */
+		if (option == PR_SET_NO_NEW_PRIVS) {
+			if (tracee->seen_execve && (int) syscall_result == 0)
+				tracee->no_new_privs = true;
+			goto end;
+		}
+
+		/* Only intercept PR_GET_AUXV. */
 		if (option != PR_GET_AUXV)
 			goto end;
 

--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -435,6 +435,8 @@ int new_child(Tracee *parent, word_t clone_flags)
 	child->sysexit_pending = parent->sysexit_pending;
 	child->execfn_addr = parent->execfn_addr;
 	child->auxv_fd = parent->auxv_fd;
+	child->no_new_privs = parent->no_new_privs;
+	child->seen_execve = parent->seen_execve;
 #ifdef HAS_POKEDATA_WORKAROUND
 	child->pokedata_workaround_stub_addr = parent->pokedata_workaround_stub_addr;
 #endif

--- a/src/tracee/tracee.h
+++ b/src/tracee/tracee.h
@@ -278,6 +278,21 @@ typedef struct tracee {
 	 * has to be ignored as it's same syscall entry */
 	bool seccomp_already_handled_enter;
 
+	/* Whether the tracee itself requested the "no new privileges" flag
+	 * via prctl(PR_SET_NO_NEW_PRIVS).  PRoot always sets the real kernel
+	 * flag in the child before execve (it is a precondition for installing
+	 * its seccomp filter), so prctl(PR_GET_NO_NEW_PRIVS) would otherwise
+	 * report 1 even though the guest never asked for it.  This field lets
+	 * PRoot report the guest's own intent instead, which is required by
+	 * tools like sudo-rs that refuse to run when the flag appears set. */
+	bool no_new_privs;
+
+	/* Set once the tracee has gone through its initial execve, i.e. once
+	 * the guest program is actually running.  Used to ignore the
+	 * PR_SET_NO_NEW_PRIVS that PRoot performs itself in the launch child
+	 * (before that execve) when tracking @no_new_privs. */
+	bool seen_execve;
+
 	/**********************************************************************
 	 * Shared or private resources, depending on the CLONE_FS/VM flags.   *
 	 **********************************************************************/


### PR DESCRIPTION
Attempt to fix sudo-rs error `The "no new privileges" flag is set, which prevents sudo from running as root.`