### PR TITLE
binding: treat symlink bind targets as directories for dir sources

### DIFF
--- a/src/path/binding.c
+++ b/src/path/binding.c
@@ -558,6 +558,16 @@ static void initialize_binding(Tracee *tracee, Binding *binding)
 		tracee->glue_type = (status < 0 || S_ISBLK(statl.st_mode) || S_ISCHR(statl.st_mode)
 				? S_IFREG : statl.st_mode & S_IFMT);
 
+		/* When the source is a directory but the guest target is
+		 * a symlink, the tracee must perceive the target as a
+		 * directory.  Dereferencing the target's final component
+		 * would register the binding at the symlink's referee
+		 * instead, leaving stat(2) on the literal target path to
+		 * report the underlying symlink -- which breaks the bind.
+		 * Keep the literal target path in that case.  */
+		if (status >= 0 && S_ISDIR(statl.st_mode))
+			dereference = false;
+
 		/* Sanitize the guest path of the binding within the
 		   alternate rootfs since it is assumed by
 		   substitute_binding().  */


### PR DESCRIPTION
Fixes issue discovered when proot'ing into [termux-docker](https://github.com/termux/termux-docker) rootfs:

* /system is a symlink to /data/data/com.termux/files/usr/opt/aosp
* Host /system is bound as-is inside rootfs
* Result is weird: we can execute host /system/bin/am however dynamic linker will attempt to pick libs from /data/data/com.termux/files/usr/opt/aosp resulting in linking error 

   ```
   06-16 20:48:14.897 17475 17475 E linker  : library "libc++.so" ("/data/data/com.termux/files/usr/opt/aosp/lib64/libc++.so") needed or dlopened by "/apex/com.android.i18n/lib64/libicu.so" is not accessible for the namespace: [name="com_android_i18n", ld_library_paths="", default_library_paths="/apex/com.android.i18n/lib64", permitted_paths="/apex/com.android.i18n/lib64:/system/lib64:/system_ext/lib64"]
   06-16 20:48:14.932 17475 17475 F linker  : CANNOT LINK EXECUTABLE "/system/bin/app_process": library "libc++.so" needed or dlopened by "/apex/com.android.i18n/lib64/libicu.so" is not accessible for the namespace "com_android_i18n"
   ```
* Moreover, if we execute `ls /system`, it will show files from host /system directory rather than from symlink target. However `stat /system` reports that /system is a symlink to `/data/data/com.termux/files/usr/opt/aosp`

So the intention is to make proot behavior sane and predictable: if source is a directory and target is a symlink, the tracee must view binding target as a directory