### PR TITLE
Build ashmem_memfd only on Android compilers

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -60,7 +60,6 @@ OBJECTS += \
 	ptrace/user.o		\
 	ptrace/wait.o		\
 	extension/extension.o	\
-	extension/ashmem_memfd/ashmem_memfd.o \
 	extension/kompat/kompat.o \
 	extension/fake_id0/chown.o \
 	extension/fake_id0/chroot.o \
@@ -89,6 +88,10 @@ OBJECTS += \
 	extension/sysvipc/sysvipc_shm.o \
 	extension/link2symlink/link2symlink.o \
 	extension/fix_symlink_size/fix_symlink_size.o
+
+ifneq ($(shell $(CC) -dM -E - < /dev/null 2>/dev/null | grep -w "#define __ANDROID__"),)
+  OBJECTS += extension/ashmem_memfd/ashmem_memfd.o
+endif
 
 define define_from_arch.h
 $2$1 := $(shell $(CC) $1 -E -dM -DNO_LIBC_HEADER $(SRC)/arch.h | grep -w $2 | cut -f 3 -d ' ')

--- a/src/cli/proot.c
+++ b/src/cli/proot.c
@@ -293,6 +293,7 @@ static int handle_option_link2symlink(Tracee *tracee, const Cli *cli UNUSED, con
 	return 0;
 }
 
+#ifdef __ANDROID__
 static int handle_option_ashmem_memfd(Tracee *tracee, const Cli *cli UNUSED, const char *value UNUSED)
 {
 	int status;
@@ -304,6 +305,7 @@ static int handle_option_ashmem_memfd(Tracee *tracee, const Cli *cli UNUSED, con
 
 	return 0;
 }
+#endif
 
 static int handle_option_sysvipc(Tracee *tracee, const Cli *cli UNUSED, const char *value UNUSED)
 {

--- a/src/cli/proot.h
+++ b/src/cli/proot.h
@@ -61,7 +61,9 @@ static int handle_option_i(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_R(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_S(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_link2symlink(Tracee *tracee, const Cli *cli, const char *value);
+#ifdef __ANDROID__
 static int handle_option_ashmem_memfd(Tracee *tracee, const Cli *cli, const char *value);
+#endif
 static int handle_option_sysvipc(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_kill_on_exit(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_L(Tracee *tracee, const Cli *cli, const char *value);
@@ -252,6 +254,7 @@ Copyright (C) 2015 STMicroelectronics, licensed under GPL v2 or later.",
 \tsyscalls inside proot. IPC is handled inside proot and launching 2 proot instances\n\
 \twill lead to 2 different IPC Namespaces",
 	},
+#ifdef __ANDROID__
 	{ .class = "Extension options",
 	  .arguments = {
 		{ .name = "--ashmem-memfd", .separator = '\0', .value = NULL },
@@ -260,6 +263,7 @@ Copyright (C) 2015 STMicroelectronics, licensed under GPL v2 or later.",
           .description = "Emulate memfd_create support through ashmem and simulate fstat.st_size for ashmem",
           .detail = "",
 	},
+#endif
         { .class = "Extension options",
           .arguments = {
                 { .name = "-H", .separator = '\0', .value = NULL },

--- a/src/extension/extension.h
+++ b/src/extension/extension.h
@@ -205,7 +205,9 @@ extern int hidden_files_callback(Extension *extension, ExtensionEvent event, int
 extern int port_switch_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
 extern int link2symlink_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
 extern int fix_symlink_size_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
+#ifdef __ANDROID__
 extern int ashmem_memfd_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
+#endif
 extern int mountinfo_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
 
 #endif /* EXTENSION_H */


### PR DESCRIPTION
Currently, `ashmem_memfd` is always built unconditionally regardless of platform. This causes build failure on desktop Linux distros due to their lack of `ashmem.h`. This change aims to facilitate desktop-based testing and to honor the `__ANDROID__` ifdef guards that have been around in many places.