### PR TITLE
canon: take alternate approach addressing deep symlinks recursion

### DIFF
--- a/src/path/canon.c
+++ b/src/path/canon.c
@@ -206,7 +206,8 @@ int canonicalize(Tracee *tracee, const char *user_path, bool deref_final,
 	unsigned int symlinks_followed = 0;
 
 	/* Avoid infinite loop on circular links.  */
-	if (recursion_level > MAXSYMLINKS)
+	//if (recursion_level > MAXSYMLINKS)
+	if (recursion_level > 3)
 		return -ELOOP;
 
 	/* Sanity checks.  */
@@ -355,18 +356,9 @@ int canonicalize(Tracee *tracee, const char *user_path, bool deref_final,
 		 * is/contains a link, moreover if it is not an
 		 * absolute link then it is relative to
 		 * 'guest_path'. */
-		{
-			char guest_path_before[PATH_MAX];
-			strcpy(guest_path_before, guest_path);
-			status = canonicalize(tracee, scratch_path, true, guest_path, recursion_level + (++symlinks_followed));
-			if (status < 0)
-				return status;
-			/* Detect self-referential symlinks (e.g. "foo -> .")
-			 * where resolution leaves guest_path unchanged,
-			 * causing infinite directory traversal.  */
-			if (strcmp(guest_path_before, guest_path) == 0)
-				return -ELOOP;
-		}
+		status = canonicalize(tracee, scratch_path, true, guest_path, recursion_level + (++symlinks_followed));
+		if (status < 0)
+			return status;
 
 		/* Check that a non-final canonicalized/dereferenced
 		 * symlink exists and is a directory.  */


### PR DESCRIPTION
With MAXSYMLINKS (8):
```
Setting up elementary-xfce-icon-theme (0.22-1) ...

real	5m10.690s
user	0m9.280s
sys	1m36.819s
```

With 3:
```
Setting up elementary-xfce-icon-theme (0.22-1) ...

real	1m25.214s
user	0m4.698s
sys	0m25.584s
```