### PR TITLE
Fix -L flag for certain ARM64 distributions (#281)

### DIFF
--- a/src/extension/fix_symlink_size/fix_symlink_size.c
+++ b/src/extension/fix_symlink_size/fix_symlink_size.c
@@ -1,4 +1,5 @@
 #include <dirent.h>    /* DIR, struct dirent, opendir, closedir, readdir) */
+#include <fcntl.h>     /* AT_* */
 #include <stdio.h>     /* rename(2), */
 #include <stdlib.h>    /* atoi */
 #include <unistd.h>    /* symlink(2), symlinkat(2), readlink(2), lstat(2), unlink(2), unlinkat(2)*/
@@ -32,6 +33,8 @@ static int handle_sysexit_end(Tracee *tracee)
 
     switch (sysnum) {
 
+    case PR_newfstatat:                //int fstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
+    case PR_fstatat64:                 //int fstatat64(int dirfd, const char *pathname, struct stat *buf, int flags);
     case PR_lstat64:                   //int lstat(const char *path, struct stat *buf);
     case PR_lstat: {                     //int lstat(const char *path, struct stat *buf);
         word_t result;
@@ -50,7 +53,17 @@ static int handle_sysexit_end(Tracee *tracee)
 
         /*for lstat, the link2symlink extension should have already drilled down to the final final and past a fake hard link
           so if the path returned points to a symbolic link, it should be a normal symbolic link*/
-        sysarg_path = SYSARG_1;
+        if (sysnum == PR_newfstatat || sysnum == PR_fstatat64) {
+            const word_t flags = peek_reg(tracee, CURRENT, SYSARG_4);
+
+            /* Only adjust results that explicitly requested lstat semantics. */
+            if ((flags & AT_SYMLINK_NOFOLLOW) == 0)
+                return 0;
+
+            sysarg_path = SYSARG_2;
+        } else {
+            sysarg_path = SYSARG_1;
+        }
         size = read_string(tracee, original, peek_reg(tracee, MODIFIED, sysarg_path), PATH_MAX);
         if (size < 0)
             return size;
@@ -73,7 +86,7 @@ static int handle_sysexit_end(Tracee *tracee)
         if (size < 0)
             return size;
 
-        sysarg_stat = SYSARG_2;
+        sysarg_stat = (sysnum == PR_newfstatat || sysnum == PR_fstatat64) ? SYSARG_3 : SYSARG_2;
 
         /* Overwrite the stat struct with the correct size. */
         read_data(tracee, &statl, peek_reg(tracee, ORIGINAL, sysarg_stat), sizeof(statl));
@@ -103,6 +116,8 @@ int fix_symlink_size_callback(Extension *extension, ExtensionEvent event,
         static FilteredSysnum filtered_sysnums[] = {
             { PR_lstat,     FILTER_SYSEXIT },
             { PR_lstat64,       FILTER_SYSEXIT },
+            { PR_newfstatat,    FILTER_SYSEXIT },
+            { PR_fstatat64,     FILTER_SYSEXIT },
             FILTERED_SYSNUM_END,
         };
         extension->filtered_sysnums = filtered_sysnums;


### PR DESCRIPTION
It turns out the reason `dpkg` keeps failing or outputting symbolic size changes warnings or errors could be dpkg arm64 calls `newfstatat` /  `fstatat64` instead of `lstat(2)` (or could be glibc arm64's implementation) which fix_symlink_size extension only hooked `lstat`/`lstatat64`

Note that I actually had this draft several months ago and had tested on Debian13 installation and Ubuntu 16.04 ARM64, so far I've never seen any errors or warnings dpkg complains symlink size changes as I use this patch. I only didn't open pull request since testing is needed as I only tested this on my device.

To test, run `apt update && apt upgrade` on the target distribution with out-of-date packages before and after using this patch

This should hopefully fix #281 